### PR TITLE
Remove benchmark BIF archives

### DIFF
--- a/causal_benchmark/algorithms/__init__.py
+++ b/causal_benchmark/algorithms/__init__.py
@@ -1,0 +1,12 @@
+"""Convenience imports for algorithm modules."""
+
+from . import pc
+from . import ges
+from . import cosmo
+
+try:
+    from . import notears  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    notears = None
+
+__all__ = ["pc", "ges", "cosmo", "notears"]

--- a/causal_benchmark/experiments/config.yaml
+++ b/causal_benchmark/experiments/config.yaml
@@ -1,5 +1,8 @@
 datasets:
   - asia
+  - sachs
+  - alarm
+  - child
 algorithms:
   pc: {}
   ges: {}

--- a/causal_benchmark/tests/test_algorithms.py
+++ b/causal_benchmark/tests/test_algorithms.py
@@ -5,11 +5,15 @@ import networkx as nx
 import pytest
 
 from utils.loaders import load_dataset
-from algorithms import pc, ges
+from algorithms import pc, ges, notears
 from metrics.metrics import shd
 
 
-@pytest.mark.parametrize('algo_module', [pc, ges])
+algorithms_to_test = [pc, ges]
+if notears is not None:
+    algorithms_to_test.append(notears)
+
+@pytest.mark.parametrize('algo_module', algorithms_to_test)
 def test_algorithms_asia(algo_module):
     data, true_graph = load_dataset('asia', n_samples=1000, force=True)
     pred_graph, _ = algo_module.run(data)

--- a/causal_benchmark/tests/test_loaders.py
+++ b/causal_benchmark/tests/test_loaders.py
@@ -1,0 +1,30 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from utils.loaders import load_dataset
+
+
+def test_asia_loader():
+    df, G = load_dataset("asia", n_samples=500, force=True)
+    assert df.shape == (500, len(G.nodes()))
+    assert ("A", "B") in G.edges()
+
+
+def test_sachs_loader():
+    df, G = load_dataset("sachs", n_samples=500, force=True)
+    assert df.shape == (500, len(G.nodes()))
+    assert len(G.nodes()) == 11
+    assert len(G.edges()) == 17
+
+
+def test_alarm_loader():
+    df, G = load_dataset("alarm", n_samples=1000, force=True)
+    assert df.shape == (1000, len(G.nodes()))
+    assert len(G.nodes()) == 37
+
+
+def test_child_loader():
+    df, G = load_dataset("child", n_samples=1000, force=True)
+    assert df.shape == (1000, len(G.nodes()))
+    assert len(G.nodes()) == 20
+

--- a/causal_benchmark/utils/download_datasets.py
+++ b/causal_benchmark/utils/download_datasets.py
@@ -2,7 +2,8 @@ from utils.loaders import load_dataset
 
 
 def main():
-    load_dataset('asia', n_samples=10000, force=True)
+    for name in ['asia', 'sachs', 'alarm', 'child']:
+        load_dataset(name, n_samples=10000, force=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- remove bundled BIF archives
- embed benchmark network structures directly in the loader
- allow algorithms tests to skip NOTEARS if its backend is missing
- keep dataset loader working for Sachs, ALARM and Child

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406e1c6c7083328f713d5a8c6b9778