### PR TITLE
Fix NOTEARS config handling and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CausalWhatNot
 
-![python](https://img.shields.io/badge/python-3.10%2B-blue)
+![python](https://img.shields.io/badge/python-3.10-blue)
 
 A reproducible benchmarking framework for causal discovery algorithms. CausalWhatNot allows researchers and practitioners to compare multiple structure learning methods on standard benchmark datasets using a consistent set of metrics.
 
@@ -10,7 +10,7 @@ The project orchestrates data generation, algorithm execution and metric computa
 
 * **PC** – constraint-based search using conditional independence tests
 * **GES** – greedy equivalence search with a BIC score
-* **NOTEARS** – continuous optimization approach via the CausalNex backend
+* **NOTEARS** – continuous optimization approach implemented with CausalNex
 * **COSMO** – priority-based regression implementation inspired by smooth acyclic orientations
 
 Results are saved as adjacency matrices and summary metrics so experiments can be reproduced exactly.
@@ -21,11 +21,15 @@ Results are saved as adjacency matrices and summary metrics so experiments can b
 * Bootstrap evaluation with precision, recall, F1 and structural hamming distance (SHD)
 * Easily extensible for new algorithms or datasets
 * Deterministic sampling with fixed seeds for reproducibility
-* Python 3.10+ compatible and tested with `pytest`
+* Developed and tested with **Python 3.10**. NOTEARS currently requires Python <3.11 due to the CausalNex dependency.
 
 ## Installation
 
-Clone the repository and install the dependencies using either `pip` or `conda`:
+Clone the repository and install the dependencies using either `pip` or `conda`.
+
+NOTEARS relies on the CausalNex library which currently only supports Python <3.11
+and requires PyTorch (installed automatically with CausalNex). A Python 3.10
+environment is therefore recommended for full functionality:
 
 ```bash
 git clone https://github.com/EDavtyan/CausalWhatNot.git
@@ -56,7 +60,7 @@ python -m causal_benchmark.experiments.run_benchmark --config causal_benchmark/e
 
 This will evaluate each algorithm on all datasets listed in the YAML config. Outputs are written to `causal_benchmark/results/` or to a custom directory via the `--out-dir` option. Each run produces:
 
-* `outputs/{dataset}_{algorithm}.csv` – learned adjacency matrices
+* `outputs/{dataset}_{algorithm}.csv` – learned adjacency matrices with node labels
 * `logs/{dataset}_{algorithm}.log` – per-run status and metrics
 * `summary_metrics.csv` – aggregate metrics (mean and std if bootstrapping)
 
@@ -81,8 +85,10 @@ All datasets are generated programmatically so no large files are required.
 |-----------|----------------|----------------|
 | **PC**    | Constraint-based search | `causallearn` |
 | **GES**   | Greedy equivalence search | `causallearn` |
-| **NOTEARS** | Continuous optimization with acyclicity constraint | `causalnex` backend |
+| **NOTEARS** | Continuous optimization with acyclicity constraint | CausalNex |
 | **COSMO** | Regression-based approach enforcing an ordering | numpy / networkx |
+
+PC and GES require the `causallearn` package. If it is not installed these algorithms will raise an `ImportError` when run.
 
 Each `run()` function returns a networkx `DiGraph` and timing information. Algorithms raise an error if a cycle is detected or required dependencies are missing.
 

--- a/causal_benchmark/algorithms/notears.py
+++ b/causal_benchmark/algorithms/notears.py
@@ -42,6 +42,9 @@ def run(
     if data.isna().any().any():
         raise ValueError("NOTEARS cannot handle missing values.")
 
+    # Ignore legacy 'backend' parameter from old configs
+    kwargs.pop('backend', None)
+
     start = time.perf_counter()
     sm = from_pandas(data, w_threshold=threshold, **kwargs)
     runtime = time.perf_counter() - start

--- a/causal_benchmark/environment.yml
+++ b/causal_benchmark/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.10
   - pip
   - pip:
-      - causallearn==0.1.3.6
+      - causal-learn==0.1.3.6
       - networkx==3.1
       - pandas==1.5.3
       - numpy==1.23.5

--- a/causal_benchmark/experiments/config.yaml
+++ b/causal_benchmark/experiments/config.yaml
@@ -6,6 +6,6 @@ datasets:
 algorithms:
   pc: {}
   ges: {}
-  notears: {backend: causalnex, threshold: 0.1}
+  notears: {threshold: 0.1}
   cosmo: {}
 bootstrap_runs: 0

--- a/causal_benchmark/experiments/run_benchmark.py
+++ b/causal_benchmark/experiments/run_benchmark.py
@@ -59,7 +59,8 @@ def run(config_path: str, output_dir: str | Path | None = None):
                     metrics['shd'] = shd(graph, true_graph)
                     if bootstrap == 0:
                         adj_path = outputs_dir / f'{dataset}_{algo_name}.csv'
-                        pd.DataFrame(nx.to_numpy_array(graph, nodelist=data.columns)).to_csv(adj_path, index=False)
+                        mat = nx.to_numpy_array(graph, nodelist=data.columns)
+                        pd.DataFrame(mat, index=data.columns, columns=data.columns).to_csv(adj_path)
                 else:
                     metrics = {'precision': 0, 'recall': 0, 'f1': 0, 'shd': -1}
 

--- a/causal_benchmark/requirements.txt
+++ b/causal_benchmark/requirements.txt
@@ -1,4 +1,4 @@
-causallearn==0.1.3.6
+causal-learn==0.1.3.6
 networkx==3.1
 pandas==1.5.3
 numpy==1.23.5

--- a/causal_benchmark/tests/test_benchmark.py
+++ b/causal_benchmark/tests/test_benchmark.py
@@ -28,3 +28,28 @@ def test_run_benchmark(tmp_path):
     assert (tmp_path / 'logs' / 'asia_ges.log').exists()
     assert summary['precision'].between(0, 1).all()
     assert summary['recall'].between(0, 1).all()
+
+
+@pytest.mark.timeout(60)
+def test_run_benchmark_notears(tmp_path):
+    try:
+        import algorithms.notears  # noqa: F401
+    except Exception:
+        pytest.skip('causalnex not installed')
+
+    cfg = {
+        'datasets': ['asia'],
+        'algorithms': {'notears': {}},
+        'bootstrap_runs': 0,
+    }
+    cfg_path = tmp_path / 'cfg.yaml'
+    with open(cfg_path, 'w') as f:
+        yaml.safe_dump(cfg, f)
+
+    run_benchmark.run(str(cfg_path), output_dir=tmp_path)
+
+    summary = pd.read_csv(tmp_path / 'summary_metrics.csv')
+    assert set(summary['algorithm']) == {'notears'}
+    assert (tmp_path / 'logs' / 'asia_notears.log').exists()
+    assert summary['precision'].between(0, 1).all()
+    assert summary['recall'].between(0, 1).all()

--- a/causal_benchmark/tests/test_helpers.py
+++ b/causal_benchmark/tests/test_helpers.py
@@ -1,0 +1,9 @@
+import numpy as np
+from utils.helpers import causallearn_to_dag
+
+
+def test_causallearn_to_dag_simple():
+    amat = np.array([[0, 1], [-1, 0]])
+    dag = causallearn_to_dag(amat, ['X', 'Y'])
+    assert list(dag.edges()) == [('X', 'Y')]
+

--- a/causal_benchmark/utils/__init__.py
+++ b/causal_benchmark/utils/__init__.py
@@ -1,0 +1,5 @@
+from .helpers import causallearn_to_dag
+
+__all__ = [
+    'causallearn_to_dag',
+]

--- a/causal_benchmark/utils/helpers.py
+++ b/causal_benchmark/utils/helpers.py
@@ -1,0 +1,25 @@
+import networkx as nx
+import numpy as np
+from typing import Iterable
+
+
+def causallearn_to_dag(amat: np.ndarray, nodes: Iterable) -> nx.DiGraph:
+    """Convert a causallearn adjacency matrix to a NetworkX ``DiGraph``.
+
+    Parameters
+    ----------
+    amat : np.ndarray
+        Adjacency matrix where 1/-1 pairs encode edge direction.
+    nodes : Iterable
+        Node labels in the desired order.
+    """
+    dag = nx.DiGraph()
+    dag.add_nodes_from(range(len(nodes)))
+    for i in range(len(nodes)):
+        for j in range(len(nodes)):
+            if amat[i, j] == 1 and amat[j, i] == -1:
+                dag.add_edge(i, j)
+            elif amat[i, j] == -1 and amat[j, i] == 1:
+                dag.add_edge(j, i)
+    return nx.relabel_nodes(dag, {i: n for i, n in enumerate(nodes)})
+


### PR DESCRIPTION
## Summary
- drop unsupported `backend` option for NOTEARS in default config
- ignore legacy `backend` argument in NOTEARs runner
- update README description of NOTEARS
- add integration test that runs benchmark with NOTEARS
- refactor PC and GES with helper function
- output adjacency matrices with column names
- document PyTorch requirement for NOTEARS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b1fd690c8332ab6b0bd6e2becf99