### PR TITLE
Fix dataset generation for benchmark test

### DIFF
--- a/causal_benchmark/tests/test_benchmark.py
+++ b/causal_benchmark/tests/test_benchmark.py
@@ -1,6 +1,12 @@
 import sys, os
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
+from utils.loaders import load_dataset
+
+# Ensure the Asia dataset exists for the benchmark tests. This avoids
+# interference from previous tests that may remove the generated file.
+load_dataset('asia', n_samples=500, force=True)
+
 from pathlib import Path
 import yaml
 import pandas as pd


### PR DESCRIPTION
## Summary
- ensure the Asia dataset is generated before running benchmark tests

## Testing
- `pytest causal_benchmark/tests/test_benchmark.py::test_run_benchmark -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bd9fb5fc83328a81ff6bb22ab393