### PR TITLE
Fix causal-learn install guidance

### DIFF
--- a/causal_benchmark/algorithms/ges.py
+++ b/causal_benchmark/algorithms/ges.py
@@ -15,7 +15,7 @@ except Exception:
 def run(data: pd.DataFrame, score_func: str = "bic") -> Tuple[nx.DiGraph, Dict[str, object]]:
     if ges is None:
         raise ImportError(
-            "causal-learn is required for the GES algorithm. Install via `pip install causal-learn`."
+            "causal-learn is required for the GES algorithm. Install via pip install causal-learn."
         )
 
     start = time.perf_counter()

--- a/causal_benchmark/algorithms/pc.py
+++ b/causal_benchmark/algorithms/pc.py
@@ -20,7 +20,7 @@ def run(
 ) -> Tuple[nx.DiGraph, Dict[str, object]]:
     if pc is None:
         raise ImportError(
-            "causal-learn is required for the PC algorithm. Install via `pip install causal-learn`."
+            "causal-learn is required for the PC algorithm. Install via pip install causal-learn."
         )
 
     start = time.perf_counter()


### PR DESCRIPTION
## Summary
- clarify missing dependency messages in PC and GES

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840c4b7cd5483329da80e12c58fcecd