### PR TITLE
Add per-dataset sample count option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This will evaluate each algorithm on all datasets listed in the YAML config. Out
 * `summary_metrics.csv` – aggregate metrics (mean and std if bootstrapping)
 
 Edit `experiments/config.yaml` to select datasets, algorithms, algorithm parameters or the number of `bootstrap_runs`.
+Each dataset entry can optionally include `n_samples` to control how many rows are generated.
 
 ## Datasets
 

--- a/causal_benchmark/experiments/config.yaml
+++ b/causal_benchmark/experiments/config.yaml
@@ -1,6 +1,7 @@
 datasets:
   - asia
-  - sachs
+  - name: sachs
+    n_samples: 5000
   - alarm
   - child
 algorithms:

--- a/causal_benchmark/experiments/run_benchmark.py
+++ b/causal_benchmark/experiments/run_benchmark.py
@@ -35,8 +35,17 @@ def run(config_path: str, output_dir: str | Path | None = None):
 
     summary_rows = []
 
-    for dataset in cfg.get('datasets', []):
-        data, true_graph = load_dataset(dataset)
+    for ds_cfg in cfg.get('datasets', []):
+        if isinstance(ds_cfg, dict):
+            dataset = ds_cfg.get('name')
+            n_samples = ds_cfg.get('n_samples')
+            if n_samples is not None:
+                data, true_graph = load_dataset(dataset, n_samples=n_samples, force=True)
+            else:
+                data, true_graph = load_dataset(dataset)
+        else:
+            dataset = ds_cfg
+            data, true_graph = load_dataset(dataset)
 
         for algo_name, params in cfg.get('algorithms', {}).items():
             mod = importlib.import_module(f'algorithms.{algo_name}')

--- a/causal_benchmark/tests/test_benchmark.py
+++ b/causal_benchmark/tests/test_benchmark.py
@@ -19,7 +19,7 @@ from utils.loaders import load_dataset
 @pytest.mark.timeout(30)
 def test_run_benchmark(tmp_path):
     cfg = {
-        'datasets': ['asia'],
+        'datasets': [{'name': 'asia', 'n_samples': 200}],
         'algorithms': {'pc': {}, 'ges': {}},
         'bootstrap_runs': 0,
     }
@@ -48,7 +48,7 @@ def test_run_benchmark_notears(tmp_path):
         pytest.skip('causalnex not installed')
 
     cfg = {
-        'datasets': ['asia'],
+        'datasets': [{'name': 'asia', 'n_samples': 200}],
         'algorithms': {'notears': {}},
         'bootstrap_runs': 0,
     }


### PR DESCRIPTION
## Summary
- allow specifying `n_samples` for each dataset in `config.yaml`
- pass optional sample count to `load_dataset` in `run_benchmark.py`
- document the new option in `README`
- adapt benchmark tests to the new dataset syntax

## Testing
- `pip install causal-learn==0.1.3.6 networkx==3.1 pandas==1.5.3 numpy==1.23.5 pyyaml==6.0 joblib==1.3.2 pytest==8.3.5`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c43532548332a98462213dfcf243