### PR TITLE
Add n_samples and timeout options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,27 @@ This will evaluate each algorithm on all datasets listed in the YAML config. Out
 * `logs/{dataset}_{algorithm}.log` – per-run status and metrics
 * `summary_metrics.csv` – aggregate metrics (mean and std if bootstrapping)
 
-Edit `experiments/config.yaml` to select datasets, algorithms, algorithm parameters or the number of `bootstrap_runs`.
-Each dataset entry can optionally include `n_samples` to control how many rows are generated.
+## Configuration
+
+Edit `experiments/config.yaml` to select datasets, algorithms and the number of `bootstrap_runs`.
+Datasets may be listed as just the name or as a mapping with optional `n_samples`:
+
+```yaml
+datasets:
+  - asia            # uses the default number of samples
+  - name: alarm
+    n_samples: 2000
+```
+
+Algorithm parameters are specified in the `algorithms` section. A `timeout_s` option can be set to abort a run if it exceeds the given number of seconds:
+
+```yaml
+algorithms:
+  pc:
+    timeout_s: 30
+```
+
+When a timeout occurs the run is marked as failed and the error is logged.
 
 ## Datasets
 

--- a/causal_benchmark/experiments/config.yaml
+++ b/causal_benchmark/experiments/config.yaml
@@ -1,12 +1,15 @@
 datasets:
-  - asia
+  # Each entry may be just the dataset name or a mapping with additional
+  # options. "n_samples" controls how many observations are generated.
+  - name: asia
   - name: sachs
     n_samples: 5000
-  - alarm
-  - child
+  - name: alarm
+  - name: child
 algorithms:
   pc: {}
   ges: {}
   notears: {threshold: 0.1}
-  cosmo: {}
+  cosmo:
+    timeout_s: 60
 bootstrap_runs: 0


### PR DESCRIPTION
## Summary
- allow datasets in config to set `n_samples`
- support optional `timeout_s` for algorithms and enforce via thread pool
- document configuration section in README
- update default config
- test dataset sample counts and timeout handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c66a5f588332aa8be64b37358781