### PR TITLE
Add edge difference diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This will evaluate each algorithm on all datasets listed in the YAML config. Out
 
 * `outputs/{dataset}_{algorithm}.csv` – learned adjacency matrices with node labels
 * `logs/{dataset}_{algorithm}.log` – per-run status and metrics
+* `logs/{dataset}_{algorithm}_diff.txt` – edge discrepancies (extra/missing/reversed)
 * `summary_metrics.csv` – aggregate metrics (mean and std if bootstrapping)
 
 ## Configuration

--- a/causal_benchmark/tests/test_benchmark.py
+++ b/causal_benchmark/tests/test_benchmark.py
@@ -36,6 +36,8 @@ def test_run_benchmark(tmp_path):
     assert set(summary['algorithm']) == {'pc', 'ges'}
     assert (tmp_path / 'logs' / 'asia_pc.log').exists()
     assert (tmp_path / 'logs' / 'asia_ges.log').exists()
+    assert (tmp_path / 'logs' / 'asia_pc_diff.txt').exists()
+    assert (tmp_path / 'logs' / 'asia_ges_diff.txt').exists()
     assert summary['precision'].between(0, 1).all()
     assert summary['recall'].between(0, 1).all()
 
@@ -63,6 +65,7 @@ def test_run_benchmark_notears(tmp_path):
     summary = pd.read_csv(tmp_path / 'summary_metrics.csv')
     assert set(summary['algorithm']) == {'notears'}
     assert (tmp_path / 'logs' / 'asia_notears.log').exists()
+    assert (tmp_path / 'logs' / 'asia_notears_diff.txt').exists()
     assert summary['precision'].between(0, 1).all()
     assert summary['recall'].between(0, 1).all()
 

--- a/causal_benchmark/tests/test_helpers.py
+++ b/causal_benchmark/tests/test_helpers.py
@@ -1,9 +1,19 @@
 import numpy as np
-from utils.helpers import causallearn_to_dag
+import networkx as nx
+from utils.helpers import causallearn_to_dag, edge_differences
 
 
 def test_causallearn_to_dag_simple():
     amat = np.array([[0, 1], [-1, 0]])
     dag = causallearn_to_dag(amat, ['X', 'Y'])
     assert list(dag.edges()) == [('X', 'Y')]
+
+
+def test_edge_differences():
+    true = nx.DiGraph([('A', 'B'), ('B', 'C')])
+    pred = nx.DiGraph([('A', 'B'), ('C', 'B'), ('A', 'C')])
+    extra, missing, rev = edge_differences(pred, true)
+    assert extra == {('A', 'C')}
+    assert missing == set()
+    assert rev == {('C', 'B')}
 

--- a/causal_benchmark/utils/helpers.py
+++ b/causal_benchmark/utils/helpers.py
@@ -1,6 +1,6 @@
 import networkx as nx
 import numpy as np
-from typing import Iterable
+from typing import Iterable, Tuple, Set
 
 
 def causallearn_to_dag(amat: np.ndarray, nodes: Iterable) -> nx.DiGraph:
@@ -22,4 +22,34 @@ def causallearn_to_dag(amat: np.ndarray, nodes: Iterable) -> nx.DiGraph:
             elif amat[i, j] == -1 and amat[j, i] == 1:
                 dag.add_edge(j, i)
     return nx.relabel_nodes(dag, {i: n for i, n in enumerate(nodes)})
+
+
+def edge_differences(
+    pred: nx.DiGraph, true: nx.DiGraph
+) -> Tuple[Set[tuple], Set[tuple], Set[tuple]]:
+    """Return extra, missing and reversed edges between two DAGs.
+
+    Parameters
+    ----------
+    pred : nx.DiGraph
+        Predicted graph.
+    true : nx.DiGraph
+        Ground truth graph.
+
+    Returns
+    -------
+    tuple of sets
+        ``(extra, missing, reversed)`` edges represented as ``(u, v)`` tuples.
+    """
+    pred_edges = set(pred.edges())
+    true_edges = set(true.edges())
+
+    pred_pairs = {frozenset(e) for e in pred_edges}
+    true_pairs = {frozenset(e) for e in true_edges}
+
+    extra = {e for e in pred_edges if frozenset(e) not in true_pairs}
+    missing = {e for e in true_edges if frozenset(e) not in pred_pairs}
+    reversed_edges = {(u, v) for (u, v) in pred_edges if (v, u) in true_edges}
+
+    return extra, missing, reversed_edges
 


### PR DESCRIPTION
## Summary
- add `edge_differences` util and tests
- log edge diffs during benchmarking
- mention new diff files in README
- test that diff files are created

## Testing
- `pip install networkx==3.1 numpy==1.23.5 pandas==1.5.3 pyyaml==6.0 joblib==1.3.2 causal-learn==0.1.3.6 pytest==8.3.5`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c99399bc83329b8250300e0afa88