### PR TITLE
Add Python version check for NOTEARS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,18 @@ Results are saved as adjacency matrices and summary metrics so experiments can b
 
 Clone the repository and install the dependencies using either `pip` or `conda`.
 
-NOTEARS relies on the CausalNex library which currently only supports Python <3.11
+NOTEARS relies on the CausalNex library which currently only supports **Python <3.11**
 and requires PyTorch (installed automatically with CausalNex). A Python 3.10
-environment is therefore recommended for full functionality:
+environment is therefore recommended for full functionality. The
+`environment.yml` provided in `causal_benchmark/` pins `python=3.10`.
+
+To create a Python 3.10 virtual environment with `venv`:
 
 ```bash
 git clone https://github.com/EDavtyan/CausalWhatNot.git
 cd CausalWhatNot
+python3.10 -m venv .venv
+source .venv/bin/activate
 pip install -r causal_benchmark/requirements.txt
 ```
 

--- a/causal_benchmark/algorithms/notears.py
+++ b/causal_benchmark/algorithms/notears.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import sys
 import time
 from typing import Tuple, Dict
 
 import networkx as nx
 import numpy as np
 import pandas as pd
+
+if sys.version_info >= (3, 11):
+    raise ImportError("NOTEARS via CausalNex only supports Python <3.11")
 
 
 try:  # optional import; fail with helpful message if unavailable

--- a/causal_benchmark/tests/test_benchmark.py
+++ b/causal_benchmark/tests/test_benchmark.py
@@ -44,6 +44,10 @@ def test_run_benchmark(tmp_path):
 
 @pytest.mark.timeout(60)
 def test_run_benchmark_notears(tmp_path):
+    if sys.version_info >= (3, 11):
+        with pytest.raises(ImportError):
+            import algorithms.notears  # noqa: F401
+        return
     try:
         import algorithms.notears  # noqa: F401
     except Exception:


### PR DESCRIPTION
## Summary
- document Python 3.10 requirement for NOTEARS in the README
- show how to create a Python 3.10 virtual environment
- guard `algorithms/notears` from running on Python 3.11+
- test that NOTEARS raises `ImportError` on unsupported Python versions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841456581c48332aa5afad80a8de050