### PR TITLE
Fix PC undirected edges and improve diff logs

### DIFF
--- a/causal_benchmark/algorithms/ges.py
+++ b/causal_benchmark/algorithms/ges.py
@@ -37,7 +37,8 @@ def run(data: pd.DataFrame, score_func: str = "bic") -> Tuple[nx.DiGraph, Dict[s
     else:
         raise AttributeError("Unknown graph representation returned by GES")
 
-    dag = causallearn_to_dag(amat, data.columns)
+    dag, meta = causallearn_to_dag(amat, data.columns)
     if not nx.is_directed_acyclic_graph(dag):
         raise RuntimeError("GES produced a cyclic graph")
-    return dag, {"runtime_s": runtime, "raw_obj": gs}
+    meta.update({"runtime_s": runtime, "raw_obj": gs})
+    return dag, meta

--- a/causal_benchmark/algorithms/pc.py
+++ b/causal_benchmark/algorithms/pc.py
@@ -43,7 +43,8 @@ def run(
     else:
         raise AttributeError("Unknown graph representation returned by PC")
 
-    dag = causallearn_to_dag(amat, data.columns)
+    dag, meta = causallearn_to_dag(amat, data.columns)
     if not nx.is_directed_acyclic_graph(dag):
         raise RuntimeError("PC produced a cyclic graph")
-    return dag, {"runtime_s": runtime, "raw_obj": cg}
+    meta.update({"runtime_s": runtime, "raw_obj": cg})
+    return dag, meta

--- a/causal_benchmark/experiments/run_benchmark.py
+++ b/causal_benchmark/experiments/run_benchmark.py
@@ -91,9 +91,10 @@ def run(config_path: str, output_dir: str | Path | None = None):
 
                 if graph is not None:
                     metrics = precision_recall_f1(graph, true_graph)
-                    metrics['shd'] = shd(graph, true_graph)
+                    metrics['shd'] = shd(graph, true_graph, pred_undirected=set(info.get('undirected_edges', [])))
                     extra, missing, rev = edge_differences(graph, true_graph)
                     with open(diff_path, 'a') as df:
+                        df.write(f'run{b}:\n')
                         for e in extra:
                             df.write(f'extra {e[0]}->{e[1]}\n')
                         for e in missing:

--- a/causal_benchmark/tests/test_benchmark.py
+++ b/causal_benchmark/tests/test_benchmark.py
@@ -130,3 +130,23 @@ def test_algorithm_timeout(tmp_path, monkeypatch):
     assert summary['precision'].iloc[0] == 0
     log_text = (tmp_path / 'logs' / 'asia_cosmo.log').read_text()
     assert 'timeout' in log_text
+
+
+@pytest.mark.timeout(30)
+def test_diff_file_run_headers(tmp_path):
+    cfg = {
+        'datasets': ['asia'],
+        'algorithms': {'pc': {}},
+        'bootstrap_runs': 2,
+    }
+    cfg_path = tmp_path / 'cfg.yaml'
+    with open(cfg_path, 'w') as f:
+        yaml.safe_dump(cfg, f)
+
+    load_dataset('asia', n_samples=100, force=True)
+
+    run_benchmark.run(str(cfg_path), output_dir=tmp_path)
+
+    diff_lines = (tmp_path / 'logs' / 'asia_pc_diff.txt').read_text().splitlines()
+    assert any(line.startswith('run0:') for line in diff_lines)
+    assert any(line.startswith('run1:') for line in diff_lines)

--- a/causal_benchmark/tests/test_helpers.py
+++ b/causal_benchmark/tests/test_helpers.py
@@ -5,8 +5,16 @@ from utils.helpers import causallearn_to_dag, edge_differences
 
 def test_causallearn_to_dag_simple():
     amat = np.array([[0, 1], [-1, 0]])
-    dag = causallearn_to_dag(amat, ['X', 'Y'])
+    dag, meta = causallearn_to_dag(amat, ['X', 'Y'])
     assert list(dag.edges()) == [('X', 'Y')]
+    assert meta['undirected_edges'] == set()
+
+
+def test_causallearn_to_dag_undirected():
+    amat = np.array([[0, 1], [1, 0]])
+    dag, meta = causallearn_to_dag(amat, ['A', 'B'])
+    assert list(dag.edges()) == [('A', 'B')]
+    assert meta['undirected_edges'] == {('A', 'B')}
 
 
 def test_edge_differences():

--- a/causal_benchmark/tests/test_metrics.py
+++ b/causal_benchmark/tests/test_metrics.py
@@ -13,3 +13,14 @@ def test_shd_precision_recall():
     assert 0 <= metrics['precision'] <= 1
     assert 0 <= metrics['recall'] <= 1
     assert 0 <= metrics['f1'] <= 1
+
+
+def test_shd_with_undirected_pred():
+    true = nx.DiGraph([(0, 1), (1, 2)])
+    pred = nx.DiGraph([(0, 1), (2, 1)])
+    undirected = {(2, 1)}
+    # Orientation of edge (2,1) is uncertain; shd should ignore its direction
+    assert shd(pred, true, cpdag_mode=True, pred_undirected=undirected) == 0
+    metrics = precision_recall_f1(pred, true, undirected_ok=True)
+    assert metrics['precision'] == 1
+    assert metrics['recall'] == 1


### PR DESCRIPTION
## Summary
- fix `causallearn_to_dag` so undirected edges are kept
- label diff.txt sections by run number
- add tests for new behaviours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419eaeac80833280218c01b1fc6f3b