### PR TITLE
Add dataset alias support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,20 @@ This will evaluate each algorithm on all datasets listed in the YAML config. Out
 
 Edit `experiments/config.yaml` to select datasets, algorithms and the number of `bootstrap_runs`.
 Set `record_edge_stability: true` to save edge frequencies computed over the bootstrap samples.
-Datasets may be listed as just the name or as a mapping with optional `n_samples`:
+Datasets may be listed as just the name or as a mapping with optional `n_samples` and `alias`:
 
 ```yaml
 datasets:
   - asia            # uses the default number of samples
   - name: alarm
     n_samples: 2000
+  - name: asia
+    alias: asia_small
+    n_samples: 500
 ```
+
+The optional `alias` lets you keep results for multiple variants of the same
+dataset separate when constructing output filenames.
 
 Algorithm parameters are specified in the `algorithms` section. A `timeout_s` option can be set to abort a run if it exceeds the given number of seconds:
 

--- a/causal_benchmark/experiments/run_benchmark.py
+++ b/causal_benchmark/experiments/run_benchmark.py
@@ -48,9 +48,11 @@ def run(config_path: str, output_dir: str | Path | None = None):
     for ds_cfg in cfg.get('datasets', []):
         if isinstance(ds_cfg, str):
             dataset = ds_cfg
+            alias = dataset
             n_samples = None
         elif isinstance(ds_cfg, dict):
             dataset = ds_cfg.get('name')
+            alias = ds_cfg.get('alias', dataset)
             n_samples = ds_cfg.get('n_samples')
         else:
             raise ValueError(f'Invalid dataset entry: {ds_cfg}')
@@ -70,7 +72,7 @@ def run(config_path: str, output_dir: str | Path | None = None):
             run_metrics = []
             run_times = []
             errors = []
-            diff_path = logs_dir / f'{dataset}_{algo_name}_diff.txt'
+            diff_path = logs_dir / f'{alias}_{algo_name}_diff.txt'
             # start a fresh diff file for this dataset/algorithm
             with open(diff_path, 'w'):
                 pass
@@ -117,7 +119,7 @@ def run(config_path: str, output_dir: str | Path | None = None):
                         for e in rev:
                             df.write(f'reversed {e[0]}->{e[1]}\n')
                     if bootstrap == 0:
-                        adj_path = outputs_dir / f'{dataset}_{algo_name}.csv'
+                        adj_path = outputs_dir / f'{alias}_{algo_name}.csv'
                         mat = nx.to_numpy_array(graph, nodelist=data.columns)
                         pd.DataFrame(mat, index=data.columns, columns=data.columns).to_csv(adj_path)
                 else:
@@ -153,7 +155,7 @@ def run(config_path: str, output_dir: str | Path | None = None):
                 shd_dir_vals = np.array([m['shd_dir'] for m in run_metrics])
             times = np.array(run_times)
 
-            log_path = logs_dir / f'{dataset}_{algo_name}.log'
+            log_path = logs_dir / f'{alias}_{algo_name}.log'
             with open(log_path, 'w') as f:
                 for i, (m, err) in enumerate(zip(run_metrics, errors)):
                     if err:
@@ -188,7 +190,7 @@ def run(config_path: str, output_dir: str | Path | None = None):
                 f.write(summary_line)
 
             row = {
-                'dataset': dataset,
+                'dataset': alias,
                 'algorithm': algo_name,
                 'precision': prec.mean(),
                 'precision_std': prec.std(ddof=0),
@@ -233,7 +235,7 @@ def run(config_path: str, output_dir: str | Path | None = None):
                     ]
                 )
                 stab_df.to_csv(
-                    logs_dir / f'{dataset}_{algo_name}_stability.csv',
+                    logs_dir / f'{alias}_{algo_name}_stability.csv',
                     index=False,
                 )
 

--- a/causal_benchmark/tests/test_benchmark.py
+++ b/causal_benchmark/tests/test_benchmark.py
@@ -171,3 +171,29 @@ def test_orientation_metrics_summary(tmp_path):
     summary = pd.read_csv(tmp_path / 'summary_metrics.csv')
     assert 'directed_precision' in summary.columns
     assert summary['directed_precision'].between(0, 1).all()
+
+
+@pytest.mark.timeout(30)
+def test_dataset_aliases(tmp_path):
+    cfg = {
+        'datasets': [
+            {'name': 'asia', 'n_samples': 100, 'alias': 'asia_a'},
+            {'name': 'asia', 'n_samples': 200, 'alias': 'asia_b'},
+        ],
+        'algorithms': {'pc': {}},
+        'bootstrap_runs': 0,
+    }
+    cfg_path = tmp_path / 'cfg.yaml'
+    with open(cfg_path, 'w') as f:
+        yaml.safe_dump(cfg, f)
+
+    load_dataset('asia', n_samples=200, force=True)
+
+    run_benchmark.run(str(cfg_path), output_dir=tmp_path)
+
+    assert (tmp_path / 'logs' / 'asia_a_pc.log').exists()
+    assert (tmp_path / 'logs' / 'asia_b_pc.log').exists()
+    assert (tmp_path / 'outputs' / 'asia_a_pc.csv').exists()
+    assert (tmp_path / 'outputs' / 'asia_b_pc.csv').exists()
+    summary = pd.read_csv(tmp_path / 'summary_metrics.csv')
+    assert set(summary['dataset']) == {'asia_a', 'asia_b'}


### PR DESCRIPTION
## Summary
- allow specifying an `alias` for datasets
- write outputs/logs using the alias
- document dataset aliases
- test dataset aliases produce separate files

## Testing
- `pip install -q causal-learn==0.1.3.6 networkx==3.1 pandas==1.5.3 numpy==1.23.5 pyyaml==6.0 joblib==1.3.2 pytest==8.3.5`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a6719160833293a461e833c2e1dc