### PR TITLE
Add discrete data detection and default scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Results are saved as adjacency matrices and summary metrics so experiments can b
 * Optional recording of edge stability frequencies across bootstrap runs
 * Easily extensible for new algorithms or datasets
 * Deterministic sampling with fixed seeds for reproducibility
+* Automatic use of chi-square and BDeu scoring when data is discrete
 * Developed and tested with **Python 3.10**. NOTEARS currently requires Python <3.11 due to the CausalNex dependency.
 
 ## Installation
@@ -125,6 +126,11 @@ All datasets are generated programmatically so no large files are required.
 | **COSMO** | Regression-based approach enforcing an ordering | numpy / networkx |
 
 PC and GES require the `causal-learn` package. Install it with `pip install causal-learn` or these algorithms will raise an `ImportError` when run.
+
+When the input data appears discrete (checked via `is_discrete()`), PC switches
+to a chi-square conditional independence test and GES uses the BDeu score. This
+behaviour can be overridden by explicitly providing `indep_test` or `score_func`
+to the respective `run()` functions.
 
 Each `run()` function returns a networkx `DiGraph` and timing information. Algorithms raise an error if a cycle is detected or required dependencies are missing.
 

--- a/causal_benchmark/algorithms/ges.py
+++ b/causal_benchmark/algorithms/ges.py
@@ -5,6 +5,7 @@ import pandas as pd
 from typing import Tuple, Dict
 
 from utils.helpers import causallearn_to_dag
+from utils.loaders import is_discrete
 
 try:
     from causallearn.search.ScoreBased.GES import ges
@@ -12,11 +13,16 @@ except Exception:
     ges = None
 
 
-def run(data: pd.DataFrame, score_func: str = "bic") -> Tuple[nx.DiGraph, Dict[str, object]]:
+def run(
+    data: pd.DataFrame, score_func: str | None = None
+) -> Tuple[nx.DiGraph, Dict[str, object]]:
     if ges is None:
         raise ImportError(
             "causal-learn is required for the GES algorithm. Install via pip install causal-learn."
         )
+
+    if score_func is None:
+        score_func = "bdeu" if is_discrete(data) else "bic"
 
     start = time.perf_counter()
     # map commonly used shorthand score names to those expected by causal-learn

--- a/causal_benchmark/utils/loaders.py
+++ b/causal_benchmark/utils/loaders.py
@@ -198,6 +198,29 @@ CHILD_STATES: dict[str, int] = {
 BASE_DIR = Path(__file__).resolve().parents[1] / 'data'
 
 
+def is_discrete(df: pd.DataFrame) -> bool:
+    """Heuristically determine if all columns are discrete.
+
+    A column is considered discrete when it has an integer, boolean or
+    categorical dtype or when floating point values are all integer-like.
+    The function returns ``True`` only if every column satisfies this
+    condition.
+    """
+
+    for col in df.columns:
+        series = df[col]
+        if (
+            pd.api.types.is_integer_dtype(series)
+            or pd.api.types.is_bool_dtype(series)
+            or pd.api.types.is_categorical_dtype(series)
+        ):
+            continue
+        if pd.api.types.is_float_dtype(series):
+            vals = series.dropna()
+            if (vals == np.floor(vals)).all():
+                continue
+        return False
+    return True
 
 
 def _sample_gaussian(G: nx.DiGraph, n: int, seed: int = 0) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- implement `is_discrete` helper for dataset inspection
- use chi-square test in PC and BDeu score in GES when data is discrete
- document automatic selection of CI test and score
- test the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a6709d3083328f123a808b77b3cd