### PR TITLE
Add pytest-timeout dependency

### DIFF
--- a/causal_benchmark/requirements.txt
+++ b/causal_benchmark/requirements.txt
@@ -6,5 +6,5 @@ pyyaml==6.0
 joblib==1.3.2
 causalnex>=0.12.0
 scikit-learn==1.6.1
-pytest==8.3.5
 pytest-timeout
+pytest==8.3.5


### PR DESCRIPTION
## Summary
- add `pytest-timeout` right after scikit-learn in requirements
- confirm `pytest-timeout` is included in the conda environment
- install Python dependencies and run tests

## Testing
- `pip install causal-learn==0.1.3.6 networkx==3.1 pandas==1.5.3 numpy==1.23.5 pyyaml==6.0 joblib==1.3.2 scikit-learn==1.6.1 pytest==8.3.5 pytest-timeout`
- `pip install -r causal_benchmark/requirements.txt` *(fails: No matching distribution found for causalnex>=0.12.0)*
- `pytest -q causal_benchmark/tests`

------
https://chatgpt.com/codex/tasks/task_e_6841c54d48548332a625b92c54f6cfdc