### PR TITLE
Add gitignore for test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,7 @@ __pycache__/
 *.pyc
 
 # Benchmark data generated during tests
-causal_benchmark/data/*
-!causal_benchmark/data/README.md
+causal_benchmark/data/
 
 # Benchmark results
 causal_benchmark/results/


### PR DESCRIPTION
## Summary
- ignore `causal_benchmark/data/` entirely
- keep ignoring compiled Python files and result outputs

## Testing
- `pytest -q` *(fails: ImportError: causal-learn is required)*

------
https://chatgpt.com/codex/tasks/task_e_6841c83babe483328657cc4107e281e3