### PR TITLE
Support dataset aliases for unique results

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ Datasets may be listed as just the name or as a mapping with optional `n_samples
 
 ```yaml
 datasets:
-  - asia            # uses the default number of samples
-  - name: alarm
-    n_samples: 2000
   - name: asia
     alias: asia_small
-    n_samples: 500
+    n_samples: 100
+  - name: asia
+    alias: asia_large
+    n_samples: 200
 ```
 
 The optional `alias` lets you keep results for multiple variants of the same

--- a/causal_benchmark/experiments/run_benchmark.py
+++ b/causal_benchmark/experiments/run_benchmark.py
@@ -47,14 +47,14 @@ def run(config_path: str, output_dir: str | Path | None = None):
     summary_rows = []
 
     for ds_cfg in cfg.get("datasets", []):
-        if isinstance(ds_cfg, str):
-            dataset = ds_cfg
-            alias = dataset
-            n_samples = None
-        elif isinstance(ds_cfg, dict):
+        if isinstance(ds_cfg, dict):
             dataset = ds_cfg.get("name")
             alias = ds_cfg.get("alias", dataset)
             n_samples = ds_cfg.get("n_samples")
+        elif isinstance(ds_cfg, str):
+            dataset = ds_cfg
+            alias = dataset
+            n_samples = None
         else:
             raise ValueError(f"Invalid dataset entry: {ds_cfg}")
 

--- a/causal_benchmark/tests/test_benchmark.py
+++ b/causal_benchmark/tests/test_benchmark.py
@@ -177,30 +177,7 @@ def test_orientation_metrics_summary(tmp_path):
 
 
 @pytest.mark.timeout(30)
-def test_dataset_aliases(tmp_path):
-    cfg = {
-        "datasets": [
-            {"name": "asia", "n_samples": 100, "alias": "asia_a"},
-            {"name": "asia", "n_samples": 200, "alias": "asia_b"},
-        ],
-        "algorithms": {"pc": {}},
-        "bootstrap_runs": 0,
-    }
-    cfg_path = tmp_path / "cfg.yaml"
-    with open(cfg_path, "w") as f:
-        yaml.safe_dump(cfg, f)
-
-    load_dataset("asia", n_samples=200, force=True)
-
-    run_benchmark.run(str(cfg_path), output_dir=tmp_path)
-
-    summary = pd.read_csv(tmp_path / 'summary_metrics.csv')
-    assert 'directed_precision' in summary.columns
-    assert summary['directed_precision'].between(0, 1).all()
-
-
-@pytest.mark.timeout(30)
-def test_dataset_aliases(tmp_path):
+def test_dataset_alias_files(tmp_path):
     cfg = {
         'datasets': [
             {'name': 'asia', 'n_samples': 100, 'alias': 'asia_a'},


### PR DESCRIPTION
## Summary
- allow optional `alias` in dataset config
- form log and output filenames using dataset alias or name
- document alias usage with a two-Asia example
- test that aliases produce separate result files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c9a128948332b0d066fe72aead05