### PR TITLE
Improve discrete heuristics and default algorithm choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,11 @@ All datasets are generated programmatically so no large files are required.
 
 PC and GES require the `causal-learn` package. Install it with `pip install causal-learn` or these algorithms will raise an `ImportError` when run.
 
-When the input data appears discrete (checked via `is_discrete()`), PC switches
-to a chi-square conditional independence test and GES uses the BDeu score. This
-behaviour can be overridden by explicitly providing `indep_test` or `score_func`
-to the respective `run()` functions.
+When the input data appears discrete (checked via `is_discrete()` which
+identifies integer-valued columns with a limited number of distinct states), PC
+switches to a chi-square conditional independence test and GES uses the BDeu
+score. This behaviour can be overridden by explicitly providing `indep_test` or
+`score_func` to the respective `run()` functions.
 
 Each `run()` function returns a networkx `DiGraph` and timing information. Algorithms raise an error if a cycle is detected or required dependencies are missing.
 

--- a/causal_benchmark/algorithms/pc.py
+++ b/causal_benchmark/algorithms/pc.py
@@ -50,5 +50,9 @@ def run(
     dag, meta = causallearn_to_dag(amat, data.columns)
     if not nx.is_directed_acyclic_graph(dag):
         raise RuntimeError("PC produced a cyclic graph")
-    meta.update({"runtime_s": runtime, "raw_obj": cg})
+    meta.update({
+        "runtime_s": runtime,
+        "raw_obj": cg,
+        "indep_test": indep_test,
+    })
     return dag, meta

--- a/causal_benchmark/tests/test_algorithms.py
+++ b/causal_benchmark/tests/test_algorithms.py
@@ -84,3 +84,26 @@ def test_discrete_default_params(monkeypatch):
     ges.run(df, score_func='bic')
     assert recorded['ges'] == 'local_score_BIC'
 
+
+def test_alarm_discrete_metadata(monkeypatch):
+    df, _ = load_dataset('alarm', n_samples=50, force=True)
+
+    def dummy_pc(data, alpha=0.05, indep_test=None, stable=True):
+        class CG:
+            pass
+
+        CG.G = type('G', (), {'graph': np.zeros((data.shape[1], data.shape[1]))})()
+        return CG()
+
+    monkeypatch.setattr(pc, 'pc', dummy_pc)
+    _, meta_pc = pc.run(df)
+    assert meta_pc['indep_test'] == 'chisq'
+
+    def dummy_ges(data, score_func=None):
+        Gobj = type('G', (), {'graph': np.zeros((data.shape[1], data.shape[1]))})()
+        return {'G': Gobj}
+
+    monkeypatch.setattr(ges, 'ges', dummy_ges)
+    _, meta_ges = ges.run(df)
+    assert meta_ges['score_func'] == 'bdeu'
+


### PR DESCRIPTION
## Summary
- refine `is_discrete` utility and document behaviour
- record independence test and score in PC/GES metadata
- add runtime fallbacks in GES for incompatible numpy
- update tests for ALARM dataset metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cb307c0083329b58c001527e1138