### PR TITLE
Add diff JSON logging helper

### DIFF
--- a/causal_benchmark/experiments/run_benchmark.py
+++ b/causal_benchmark/experiments/run_benchmark.py
@@ -11,7 +11,7 @@ import sys, os
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from utils.loaders import load_dataset
-from utils.helpers import edge_differences
+from utils.helpers import edge_differences, dump_edge_differences_json
 from metrics.metrics import (
     shd,
     precision_recall_f1,
@@ -123,6 +123,8 @@ def run(config_path: str, output_dir: str | Path | None = None):
                             df.write(f"missing {e[0]}->{e[1]}\n")
                         for e in rev:
                             df.write(f"reversed {e[0]}->{e[1]}\n")
+                    diff_json_path = logs_dir / f"{alias}_{algo_name}_diff_run{b}.json"
+                    dump_edge_differences_json(extra, missing, rev, diff_json_path)
                     if bootstrap == 0:
                         adj_path = outputs_dir / f'{alias}_{algo_name}.csv'
                         mat = nx.to_numpy_array(graph, nodelist=data.columns)

--- a/causal_benchmark/requirements.txt
+++ b/causal_benchmark/requirements.txt
@@ -4,7 +4,8 @@ pandas==1.5.3
 numpy==1.23.5
 pyyaml==6.0
 joblib==1.3.2
-causalnex>=0.12.0
+# NOTEARS requires causalnex which is not available for Python >=3.11
+causalnex>=0.12.0; python_version < '3.11'
 scikit-learn==1.6.1
 pytest-timeout
 pytest==8.3.5

--- a/causal_benchmark/tests/test_benchmark.py
+++ b/causal_benchmark/tests/test_benchmark.py
@@ -10,6 +10,7 @@ load_dataset("asia", n_samples=500, force=True)
 
 from pathlib import Path
 import yaml
+import json
 import pandas as pd
 import pytest
 
@@ -39,6 +40,13 @@ def test_run_benchmark(tmp_path):
     assert (tmp_path / "logs" / "asia_ges.log").exists()
     assert (tmp_path / "logs" / "asia_pc_diff.txt").exists()
     assert (tmp_path / "logs" / "asia_ges_diff.txt").exists()
+    assert (tmp_path / "logs" / "asia_pc_diff_run0.json").exists()
+    assert (tmp_path / "logs" / "asia_ges_diff_run0.json").exists()
+    for p in [tmp_path / "logs" / "asia_pc_diff_run0.json", tmp_path / "logs" / "asia_ges_diff_run0.json"]:
+        data = json.loads(p.read_text())
+        assert set(data) == {"extra", "missing", "reversed"}
+        for lst in data.values():
+            assert isinstance(lst, list)
     assert summary["precision"].between(0, 1).all()
     assert summary["recall"].between(0, 1).all()
 
@@ -75,6 +83,9 @@ def test_run_benchmark_notears(tmp_path):
     assert set(summary["algorithm"]) == {"notears"}
     assert (tmp_path / "logs" / "asia_notears.log").exists()
     assert (tmp_path / "logs" / "asia_notears_diff.txt").exists()
+    assert (tmp_path / "logs" / "asia_notears_diff_run0.json").exists()
+    data = json.loads((tmp_path / "logs" / "asia_notears_diff_run0.json").read_text())
+    assert set(data) == {"extra", "missing", "reversed"}
     assert summary["precision"].between(0, 1).all()
     assert summary["recall"].between(0, 1).all()
 
@@ -182,6 +193,11 @@ def test_diff_file_run_headers(tmp_path):
     diff_lines = (tmp_path / "logs" / "asia_pc_diff.txt").read_text().splitlines()
     assert any(line.startswith("run0:") for line in diff_lines)
     assert any(line.startswith("run1:") for line in diff_lines)
+    for i in (0, 1):
+        p = tmp_path / "logs" / f"asia_pc_diff_run{i}.json"
+        assert p.exists()
+        data = json.loads(p.read_text())
+        assert set(data) == {"extra", "missing", "reversed"}
 
 
 @pytest.mark.timeout(30)
@@ -225,6 +241,8 @@ def test_dataset_alias_files(tmp_path):
 
     assert (tmp_path / 'logs' / 'asia_a_pc.log').exists()
     assert (tmp_path / 'logs' / 'asia_b_pc.log').exists()
+    assert (tmp_path / 'logs' / 'asia_a_pc_diff_run0.json').exists()
+    assert (tmp_path / 'logs' / 'asia_b_pc_diff_run0.json').exists()
     assert (tmp_path / 'outputs' / 'asia_a_pc.csv').exists()
     assert (tmp_path / 'outputs' / 'asia_b_pc.csv').exists()
     summary = pd.read_csv(tmp_path / 'summary_metrics.csv')

--- a/causal_benchmark/utils/helpers.py
+++ b/causal_benchmark/utils/helpers.py
@@ -1,6 +1,7 @@
 import networkx as nx
 import numpy as np
 from typing import Iterable, Tuple, Set, Dict
+import json
 
 
 def causallearn_to_dag(amat: np.ndarray, nodes: Iterable) -> Tuple[nx.DiGraph, Dict[str, object]]:
@@ -60,4 +61,28 @@ def edge_differences(
     reversed_edges = {(u, v) for (u, v) in pred_edges if (v, u) in true_edges}
 
     return extra, missing, reversed_edges
+
+
+def dump_edge_differences_json(
+    extra: Iterable[Tuple[str, str]],
+    missing: Iterable[Tuple[str, str]],
+    reversed_edges: Iterable[Tuple[str, str]],
+    path: str,
+) -> None:
+    """Write edge difference lists to ``path`` in JSON format.
+
+    Parameters
+    ----------
+    extra, missing, reversed_edges : iterable of edge tuples
+        Edge lists to write out.
+    path : str
+        Destination file path.
+    """
+    data = {
+        "extra": [[u, v] for u, v in sorted(extra)],
+        "missing": [[u, v] for u, v in sorted(missing)],
+        "reversed": [[u, v] for u, v in sorted(reversed_edges)],
+    }
+    with open(path, "w") as f:
+        json.dump(data, f)
 


### PR DESCRIPTION
## Summary
- add `dump_edge_differences_json` utility to store diff lists
- log diff JSON files for each run in `run_benchmark`
- test diff JSON output for algorithms and bootstraps
- make `causalnex` an optional dependency for Python 3.11+

## Testing
- `pip install -q -r causal_benchmark/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d2092918833287f8c1a6089a5705