### PR TITLE
Add graph mis-specification utility

### DIFF
--- a/causal_benchmark/tests/test_graph_ops.py
+++ b/causal_benchmark/tests/test_graph_ops.py
@@ -1,0 +1,27 @@
+import networkx as nx
+import pytest
+
+from utils import create_mis_specified_graph
+
+
+def test_create_mis_specified_graph_missing():
+    g = nx.DiGraph([('A', 'B'), ('B', 'C')])
+    mis = create_mis_specified_graph(g, 'missing', 'A', 'B')
+    assert set(mis.edges()) == {('B', 'C')}
+
+
+def test_create_mis_specified_graph_spurious():
+    g = nx.DiGraph([('A', 'B')])
+    mis = create_mis_specified_graph(g, 'spurious', 'B', 'A')
+    assert set(mis.edges()) == {('A', 'B'), ('B', 'A')}
+
+
+def test_create_mis_specified_graph_errors():
+    g = nx.DiGraph([('A', 'B')])
+    with pytest.raises(ValueError):
+        create_mis_specified_graph(g, 'missing', 'B', 'A')
+    with pytest.raises(ValueError):
+        create_mis_specified_graph(g, 'spurious', 'A', 'B')
+    with pytest.raises(ValueError):
+        create_mis_specified_graph(g, 'invalid', 'A', 'B')
+

--- a/causal_benchmark/utils/__init__.py
+++ b/causal_benchmark/utils/__init__.py
@@ -1,5 +1,7 @@
 from .helpers import causallearn_to_dag
+from .graph_ops import create_mis_specified_graph
 
 __all__ = [
     'causallearn_to_dag',
+    'create_mis_specified_graph',
 ]

--- a/causal_benchmark/utils/graph_ops.py
+++ b/causal_benchmark/utils/graph_ops.py
@@ -11,3 +11,58 @@ def cpdag_to_dag(cpdag: nx.DiGraph) -> nx.DiGraph:
 def adjacency_to_nx(adj: np.ndarray, nodes) -> nx.DiGraph:
     G = nx.DiGraph(adj)
     return nx.relabel_nodes(G, {i: n for i, n in enumerate(nodes)})
+
+
+def create_mis_specified_graph(true_graph: nx.DiGraph, error_type: str, u: str, v: str) -> nx.DiGraph:
+    """Create a mis-specified version of a graph by modifying a single edge.
+
+    Parameters
+    ----------
+    true_graph:
+        Original directed acyclic graph.
+    error_type:
+        Either ``"missing"`` to remove an existing edge or ``"spurious"`` to add
+        a new edge.
+    u, v:
+        Source and target nodes of the edge to modify.
+
+    Returns
+    -------
+    nx.DiGraph
+        A copy of ``true_graph`` with the specified edge removed or added.
+
+    Raises
+    ------
+    ValueError
+        If ``error_type`` is not recognized, if the nodes do not exist in the
+        graph, or if the requested edge already satisfies/violates the
+        specified error type.
+
+    Examples
+    --------
+    >>> import networkx as nx
+    >>> G = nx.DiGraph([('X', 'Y')])
+    >>> create_mis_specified_graph(G, 'missing', 'X', 'Y').has_edge('X', 'Y')
+    False
+    >>> create_mis_specified_graph(G, 'spurious', 'Y', 'X').has_edge('Y', 'X')
+    True
+    """
+
+    if error_type not in {"missing", "spurious"}:
+        raise ValueError("error_type must be either 'missing' or 'spurious'")
+
+    if u not in true_graph.nodes or v not in true_graph.nodes:
+        raise ValueError("Both u and v must be nodes in true_graph")
+
+    mis_graph = true_graph.copy()
+
+    if error_type == "missing":
+        if not true_graph.has_edge(u, v):
+            raise ValueError(f"Edge ({u}, {v}) does not exist in true_graph")
+        mis_graph.remove_edge(u, v)
+    else:  # error_type == "spurious"
+        if true_graph.has_edge(u, v):
+            raise ValueError(f"Edge ({u}, {v}) already exists in true_graph")
+        mis_graph.add_edge(u, v)
+
+    return mis_graph


### PR DESCRIPTION
## Summary
- create_mis_specified_graph helper for generating missing or spurious edges
- export utility via utils package
- add tests for mis-specified graph creation

## Testing
- `PYENV_VERSION=3.10.17 pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b42f742bcc832baf77439b896ecc11