### PR TITLE
feat: export phase3 results as csv

### DIFF
--- a/causal_benchmark/README.md
+++ b/causal_benchmark/README.md
@@ -8,3 +8,16 @@ pip install -r requirements.txt
 python utils/download_datasets.py
 python experiments/run_benchmark.py --config experiments/config.yaml
 ```
+
+To run the phase 3 sensitivity analysis and write a summary CSV:
+
+```bash
+python experiments/phase3_sensitivity_analysis.py \
+    --n-samples 100 \
+    --bootstrap-runs 10 \
+    --out-dir results \
+    --diff-logs
+```
+
+This creates `results/phase3_results.csv` and, when `--diff-logs` is set,
+per-algorithm difference logs under `results/diff_logs/`.


### PR DESCRIPTION
## Summary
- allow phase3 analysis to write phase3_results.csv and optional diff logs
- capture optional BIC scores and return results as a DataFrame
- document how to run the phase3 sensitivity analysis script

## Testing
- `python -m pytest` *(fails: pyenv: version `3.10.14` is not installed)*
- `/usr/bin/python3 -m venv venv && source venv/bin/activate && pip install -r causal_benchmark/requirements.txt` *(fails: ModuleNotFoundError: No module named 'distutils')*


------
https://chatgpt.com/codex/tasks/task_b_68b4501853f0832b85270c06f2fee6e8